### PR TITLE
Concerta comando de restauração do banco

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Você pode também instalar o plugin do `ESLint` no `VSCode`, bastar ir em exten
 
 3. Na raiz do diretório do projeto, execute o seguinte comando que fará a restauração da base de dados `commerce`:
    ```sh
-   DBNAME=commerce ./scripts/resetdb.sh assets
+   DBNAME=commerce ./scripts/resetdb.sh assets/produtos
    ```
 
 - A execução desse script criará um banco de dados chamado `commerce` e importará os dados para a coleção `produtos`.

--- a/scripts/evaluate.sh
+++ b/scripts/evaluate.sh
@@ -8,4 +8,4 @@ fi
 
 export DBNAME=commerce
 
-scripts/generate_result.sh "$PWD/challenges" "$PWD/.trybe" "$PWD/assets"
+scripts/generate_result.sh "$PWD/challenges" "$PWD/.trybe" "$PWD/assets/produtos"


### PR DESCRIPTION
@phelipe-ohlsen, apontou que o caminho do arquivo para restauração do banco de dados foi alterado para `assets/produtos`, portanto esse alinhamento precisa ser feito no readme.
Essa alteração foi feita por causa do PR https://github.com/betrybe/sd-0x-mongodb-commerce/pull/8 na qual foi atualizada a versão da action do avaliador de mongo e ela checa pastas dentro de `assets`, no padrão: `assets/*/*.tar.gz` como explicado pelo @eucleciojosias via Slack
staging: https://github.com/betrybe/sd-00-staging-mongodb-commerce/pull/2